### PR TITLE
fix for supporting argocd sync

### DIFF
--- a/chart/templates/pki.yaml
+++ b/chart/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "dnspod-webhook.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "dnspod-webhook.selfSignedIssuer" . }}
   commonName: "ca.dnspod-webhook.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "dnspod-webhook.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "dnspod-webhook.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
When deploying this chart using ArgoCD, The `duration` is out of sync. 