### PR TITLE
ci: Add multi-arch docker image build via Github Actions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,111 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+    - master
+    - releases/**
+
+    tags:
+    - v*
+
+    paths-ignore:
+    - '**.md'
+    - bundle.yaml
+    - chart/**
+
+env:
+  REGISTRY_IMAGE: imroc/cert-manager-webhook-dnspod
+
+jobs:
+  build:
+    if: github.repository == 'imroc/cert-manager-webhook-dnspod'
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/arm64
+        - linux/arm/v6
+        - linux/arm/v7
+        - linux/386
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        provenance: false
+        platforms: ${{ matrix.platform }}
+        labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+    - name: Upload digest
+      uses: actions/upload-artifact@v3
+      with:
+        name: digests
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs:
+    - build
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v3
+      with:
+        name: digests
+        path: /tmp/digests
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Create manifest list and push
+      working-directory: /tmp/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 
 # Ignore the built binary
 cert-manager-webhook-example
+webhook
+apiserver.local.config/
 
 # Make artifacts
 _out


### PR DESCRIPTION
Add multi-arch docker image build via Github Actions

This PR, we can support the following platforms.
- linux/amd64
- linux/arm64
- linux/arm/v6
- linux/arm/v7
- linux/386

现在有不少arm64架构的系统，因此支持多CPU架构很有必要。

@imroc 合并前需要配置Token：
1. 在Docker Hub中Account Settings->[Security](https://hub.docker.com/settings/security)创建Access Tokens (scope: Read & Write)
2. 在本仓库[Secrets and variables](https://github.com/imroc/cert-manager-webhook-dnspod/settings/secrets/actions)设置中`Repository secrets`下添加两个环境变量：
* DOCKERHUB_USERNAME
* DOCKERHUB_TOKEN
3. 重新创建tag v1.3.0 触发Actions

这个github actions经过测试，完成用时21分钟左右
```bash
docker pull moechs/cert-manager-webhook-dnspod:1.3.0
```

